### PR TITLE
Fix bug where user can resize Plasma desktop wallpaper

### DIFF
--- a/contents/code/main.js
+++ b/contents/code/main.js
@@ -52,6 +52,12 @@ function center(geometry) {
 }
 
 function manage(index, rs, cs, r, c) {
+  // Do not modify the geometry of a desktop window. It probably needs to
+  // be fullscreen to display desktop wallpaper and icons.
+  if (workspace.activeClient.desktopWindow) {
+    return;
+  }
+
   /*
    * Index is the zero-index of the square in the grid.
    * For example, if index=2, r=2, c=2, then


### PR DESCRIPTION
I noticed that kwin-rectangle can resize the Plasma desktop wallpaper window if it's focused. It seems like a bug since it's difficult to get the wallpaper back to fullscreen dimensions due to tiling gaps. This small PR blocks this by preventing the `manage()` function from operating on `_NET_WM_WINDOW_TYPE_DESKTOP` type windows.

Happy to hear any feedback. Thanks!